### PR TITLE
Exclude development tools from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends maven \
 	&& patch src/main/resources/portal.properties </root/portal.properties.patch \
 	&& cp src/main/resources/log4j.properties.EXAMPLE src/main/resources/log4j.properties \
 	&& mvn -DskipTests clean install \
-	&& mv portal/target/cbioportal-*.war $CATALINA_HOME/webapps/cbioportal.war \
+	# deploy the war to the Tomcat web container
+	&& unzip portal/target/cbioportal-*.war -d $CATALINA_HOME/webapps/cbioportal/ \
 	# save the scripts jar needed for importing, so Maven does not clean it up
 	&& mv scripts/target/scripts-*.jar /root/ \
 	&& mvn clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends maven \
 	&& cp src/main/resources/log4j.properties.EXAMPLE src/main/resources/log4j.properties \
 	&& mvn -DskipTests clean install \
 	&& mv portal/target/cbioportal-*.war $CATALINA_HOME/webapps/cbioportal.war \
+	# save the scripts jar needed for importing, so Maven does not clean it up
+	&& mv scripts/target/scripts-*.jar /root/ \
+	&& mvn clean \
+	&& mkdir scripts/target/ \
+	&& mv /root/scripts-*.jar scripts/target/ \
 	&& apt-get purge -y maven && apt-get autoremove -y --purge
 
 # add runtime configuration

--- a/example_commands.md
+++ b/example_commands.md
@@ -48,40 +48,11 @@ The import command:
 
 ### Running cBioPortal code from a local folder ###
 
-If you have checked out (or modified) a git branch locally in `~/cbioportal`
-and you want to run or debug it, you can use the following command. Note that
-the path given to the `-v` option must be an absolute path. The mapping for
-port 8000 and the references to JPDA open a port for remote debugging software
-to attach. The image is used as a runtime environment and as a cache for
-dependencies when compiling, while the `portal.properties` file will be read
-from the source folder.
-
-```shell
-docker run --rm \
-    -p 8000:8000 \
-    -p 8080:8080 \
-    -v "$HOME"/cbioportal:/cbioportal \
-    --net=cbio-net \
-    --name=cbioportal-dev \
-    cbioportal-image \
-    sh -c 'mvn -DskipTests clean install && rm -f "$CATALINA_HOME/webapps/cbioportal.war" && unzip portal/target/cbioportal*.war -d "$CATALINA_HOME/webapps/cbioportal/" && JPDA_ADDRESS=0.0.0.0:8000 exec catalina.sh jpda run'
-```
+TODO: document building images based on a different online git
+branch or a local folder, and using volumes to overwrite frontend
+resources on the fly
 
 ### Testing cBioPortal code from a GitHub branch ###
-
-If you want to run and test code from a branch you have not checked out
-locally, say from someone else’s pull request, you can use a command like the
-following. This example checks out the `rc` branch of the GitHub repository for
-`thehyve`.
-
-```shell
-docker run --rm \
-    -p 8081:8080 \
-    --net=cbio-net \
-    --name=cbioportal-test \
-    cbioportal-image \
-    sh -c 'git fetch https://github.com/thehyve/cbioportal.git rc && git checkout FETCH_HEAD && mvn -DskipTests clean install && rm -f "$CATALINA_HOME/webapps/cbioportal.war" && unzip portal/target/cbioportal*.war -d "$CATALINA_HOME/webapps/cbioportal/" && exec catalina.sh run'
-```
 
 ### Inspecting or adjusting the database ###
 


### PR DESCRIPTION
This will decrease the image size by about 430MiB (down to 850 MiB), and remove potentially vulnerable software that is unnecessary for maintaining a cBioPortal instance.

It still needs some work though -- I have not yet tested whether data loading runs as expected, or worked out how to use this version for development, and testing. See `example_commands.md`.
