### PR TITLE
LDAP documentation: Fix error in a command

### DIFF
--- a/docs/using-ldap.md
+++ b/docs/using-ldap.md
@@ -101,7 +101,7 @@ while (again) authenticating as the admin user to make the change:
 ```shell
 docker run --rm -it \
     --net=authnet \
-    openldap:utils \
+    openldap:withtools \
     ldappasswd -H ldap://ldap-server -xWD cn=admin,dc=cbio,dc=local -S \
         uid=foo,ou=people,dc=cbio,dc=local
 ```


### PR DESCRIPTION
I was following the LDAP documentation you wrote, @fedde-s. I believe there is a mistake in the document, so I propose to correct it. 