### PR TITLE
Update to v1.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # fetch the cBioPortal sources and version control metadata
 ENV PORTAL_HOME=/cbioportal
-RUN git clone --depth 1 -b v1.8.3 'https://github.com/cBioPortal/cbioportal.git' $PORTAL_HOME
+RUN git clone --depth 1 -b v1.9.0 'https://github.com/cBioPortal/cbioportal.git' $PORTAL_HOME
 WORKDIR $PORTAL_HOME
 
 #RUN git fetch --depth 1 https://github.com/thehyve/cbioportal.git my_development_branch \

--- a/portal.properties.patch
+++ b/portal.properties.patch
@@ -19,7 +19,7 @@
 < skin.example_study_queries=tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast
 ---
 > skin.authorization_message=Access to this portal is only available to authorized users.
-> skin.example_study_queries=
+> skin.example_study_queries="cell line"\nlung -neuroendocrine\nesophageal OR stomach\nbreast
 25c25
 < skin.data_sets_footer=Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.
 ---

--- a/portal.properties.patch
+++ b/portal.properties.patch
@@ -1,53 +1,47 @@
---- portal.properties.EXAMPLE
-+++ portal.properties
-@@ -3,12 +3,12 @@
- app.version=${timestamp}
- 
- # database
--db.user=cbio_user
--db.password=somepassword
--db.host=localhost
-+db.user=cbio
-+db.password=P@ssword1
-+db.host=cbioDB
- db.portal_db_name=cbioportal
- db.driver=com.mysql.jdbc.Driver
--db.connection_string=jdbc:mysql://localhost/
-+db.connection_string=jdbc:mysql://cbioDB/
- db.tomcat_resource_name=jdbc/cbioportal
- # this is the *expected* DB version (expected by the code). Don't set it manually, it is filled by maven:
- db.version=${db.version}
-@@ -16,9 +16,9 @@
- db.suppress_schema_version_mismatch_errors=false
- 
- # web page cosmetics
--skin.title=cBioPortal for Cancer Genomics
-+skin.title=Local cBioPortal instance
- skin.email_contact=cbioportal at googlegroups dot com
--skin.authorization_message=Access to this portal is only available to authorized users at Memorial Sloan Kettering Cancer Center.  [<a href="http://bit.ly/ZevaHa">Request Access</a>].
-+skin.authorization_message=Access to this portal is only available to authorized users.
- skin.example_study_queries=tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast
- skin.data_sets_header=The portal currently contains data from the following cancer genomics studies.  The table below lists the number of available samples per data type and tumor.
- skin.data_sets_footer=Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.
-@@ -55,10 +55,10 @@
- skin.footer= | <a href="http://www.mskcc.org/mskcc/html/44.cfm">MSKCC</a> | <a href="http://cancergenome.nih.gov/">TCGA</a>
- 
- # setting controlling html for the contact
--skin.login.contact_html=If you think you have received this message in error, please contact us at <a style="color:#FF0000" href="mailto:cbioportal-access@cbio.mskcc.org">cbioportal-access@cbio.mskcc.org</a>
-+skin.login.contact_html=If you think you have received this message in error, please contact us
- 
- # setting controlling the saml registration
--skin.login.saml.registration_html=Sign in with MSK
-+skin.login.saml.registration_html=Sign in
- 
- # settings controlling what to show in the right navigation bar
- skin.right_nav.show_data_sets=true
-@@ -165,7 +165,7 @@
- pathway_commons.url=http://www.pathwaycommons.org/pc2
- 
- # bitly, please use your bitly user and apiKey
--bitly.url=http://api.bit.ly/shorten?login=[bitly.user]&apiKey=[bitly.apiKey]&
-+bitly.url=
- 
- # google analytics
- google_analytics_profile_id=
+7,9c7,9
+< db.user=cbio_user
+< db.password=somepassword
+< db.host=localhost
+---
+> db.user=cbio
+> db.password=P@ssword1
+> db.host=cbioDB
+12c12
+< db.connection_string=jdbc:mysql://localhost/
+---
+> db.connection_string=jdbc:mysql://cbioDB/
+20c20
+< skin.title=cBioPortal for Cancer Genomics
+---
+> skin.title=Local cBioPortal instance
+22,23c22,23
+< skin.authorization_message=Access to this portal is only available to authorized users at Memorial Sloan Kettering Cancer Center.  [<a href="http://bit.ly/ZevaHa">Request Access</a>].
+< skin.example_study_queries=tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast
+---
+> skin.authorization_message=Access to this portal is only available to authorized users.
+> skin.example_study_queries=
+25c25
+< skin.data_sets_footer=Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.
+---
+> skin.data_sets_footer=
+56c56
+< skin.footer= | <a href="http://www.mskcc.org/mskcc/html/44.cfm">MSKCC</a> | <a href="http://cancergenome.nih.gov/">TCGA</a>
+---
+> skin.footer=
+59c59
+< skin.login.contact_html=If you think you have received this message in error, please contact us at <a style="color:#FF0000" href="mailto:cbioportal-access@cbio.mskcc.org">cbioportal-access@cbio.mskcc.org</a>
+---
+> skin.login.contact_html=If you think you have received this message in error, please contact us
+62c62
+< skin.login.saml.registration_html=Sign in with MSK
+---
+> skin.login.saml.registration_html=Sign in
+169c169
+< bitly.url=http://api.bit.ly/shorten?login=[bitly.user]&apiKey=[bitly.apiKey]&
+---
+> bitly.url=
+227c227,228
+< # Change this to custom file (e.g. file:/<path>) to have a custom set of genes in query page:
+---
+> # Change this to custom JSON file (e.g. file:/<path>) to have a custom set of genes in query page.
+> # JSON format should be in format of: https://github.com/cBioPortal/cbioportal-frontend/blob/master/src/shared/components/query/gene_lists.ts


### PR DESCRIPTION
Also removed some configurable text that is specific for MSK and TCGA and clarified custom gene sets.

Diff between the resulting `portal.properties` files:
```diff
Sanders-MacBook-Pro:docker_cbioportal sander$ diff portal.properties-183 portal.properties-190 
3a4
> portal.version=${project.version}
22c23
< skin.example_study_queries=tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast
---
> skin.example_study_queries=
24c25
< skin.data_sets_footer=Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.
---
> skin.data_sets_footer=
55c56
< skin.footer= | <a href="http://www.mskcc.org/mskcc/html/44.cfm">MSKCC</a> | <a href="http://cancergenome.nih.gov/">TCGA</a>
---
> skin.footer=
204a206,229
> 
> # labels to be displayed in oncoprint "Mutation color" menu for custom annotation of driver and passenger mutations in the oncoprint.
> # Set any of these properties to enable the respective menu options in oncoprint:
> # oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotation
> # oncoprint.custom_driver_annotation.tiers.menu_label=Custom driver tiers
> 
> # set this to false to disable the automatic selection of the custom driver/passenger mutations annotation (binary) in the oncoprint
> # when custom annotation data is present.
> # oncoprint.custom_driver_annotation.default=false
> 
> # set this to false to disable the automatic selection of the custom tiers in the oncoprint when custom annotation data is present. By default
> # this property is true.
> # oncoprint.custom_driver_tiers_annotation.default=false
> 
> # OncoKB and Hotspots are automatically selected as annotation source. If you want to disable them, set the following property to false. If you
> # want them to be selected only if there are no custom annotation driver and passenger mutations, type "custom".
> # oncoprint.oncokb_hotspots.default=custom
> 
> # Set this to true if you want to check the "hide Putative Passenger Mutations" checkbox by default.
> # oncoprint.hide_passenger.default=true
> 
> # Change this to custom JSON file (e.g. file:/<path>) to have a custom set of genes in query page.
> # JSON format should be in format of: https://github.com/cBioPortal/cbioportal-frontend/blob/master/src/shared/components/query/gene_lists.ts
> # querypage.setsofgenes.location =
Sanders-MacBook-Pro:docker_cbioportal sander$
```