### PR TITLE
use build arg from Docker spec to select a specific branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python-requests \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& ln -s /usr/share/java/mysql-connector-java.jar "$CATALINA_HOME"/lib/ \
-	&& rm -rf $CATALINA_HOME/webapps/*m* 
-	
+	&& rm -rf $CATALINA_HOME/webapps/*m*
+
+ARG BRANCH=master
+ARG COMMIT=
+ARG REPOSITORY=https://github.com/cBioPortal/cbioportal.git
+
+LABEL thehyve.cbioportal.commit="${COMMIT}" thehyve.cbioportal.branch="${BRANCH}" thehyve.cbioportal.repository="${REPOSITORY}"
+LABEL thehyve.dockerfile.repository="https://github.com/thehyve/cbioportal-docker.git"
+
+ENV PORTAL_HOME=/cbioportal
 
 # fetch the cBioPortal sources and version control metadata
-ENV PORTAL_HOME=/cbioportal
-RUN git clone --depth 1 -b v1.11.2 'https://github.com/cBioPortal/cbioportal.git' $PORTAL_HOME
-WORKDIR $PORTAL_HOME
+RUN echo "git clone --single-branch --depth 1 -b ${BRANCH} ${REPOSITORY} ${PORTAL_HOME}" ; git clone --single-branch --depth 1 -b ${BRANCH} ${REPOSITORY} ${PORTAL_HOME} 2> /dev/null
 
-#RUN git fetch --depth 1 https://github.com/thehyve/cbioportal.git my_development_branch \
-#       && git checkout commit_hash_in_branch
+WORKDIR ${PORTAL_HOME}
+
+RUN if [ "${COMMIT}" != "" ] ; then git fetch --unshallow ${REPOSITORY} ; git checkout ${COMMIT} 2> /dev/null ; fi
 
 # add buildtime configuration
 COPY ./portal.properties src/main/resources/portal.properties

--- a/docs/adjusting_configuration.md
+++ b/docs/adjusting_configuration.md
@@ -1,34 +1,41 @@
 # Adjusting cBioPortal
 
 ## Customize cBioPortal configuration
+
 When building a Docker image, the Dockerfile adjusts configuration by copying cBioPortal configuration files `portal.properties` and `log4j.properties` to the image. To build an image that uses different settings (see the documentation on the [main properties](https://github.com/cBioPortal/cbioportal/blob/master/docs/portal.properties-Reference.md) and the [skin properties](https://github.com/cBioPortal/cbioportal/blob/master/docs/Customizing-your-instance-of-cBioPortal.md)), you can follow the steps listed below. The `log4j.properties` file can modified to change the log level.
 
 To modify the configuration for your own cBioPortal instance, please add modifications to `portal.properties` and `log4j.properties`. This file already contains several modifications for this Docker setup. The original configuration of the dockerized version of cBioPortal can be found in `portal.properties.EXAMPLE` and `log4j.properties.EXAMPLE`. To view differences between the original file and modified file, use `diff`:
+
 ```
 diff portal.properties portal.properties.EXAMPLE
 ```
 
 ## Use a different cBioPortal branch
-The default configuration to run containers creates an image based on the current version of cBioPortal. The branch used to build the image is specified in the Dockerfile. 
 
-To use a different branch, you must know the branch name and the latest commit of this branch that you want to apply to your image, and specify them in the `Dockerfile`. For instance, if you want to build a cBioPortal image based on commit `6b9356aecdce4068543156e6b1b4509ce89cae66` of `rc`, you should find this part in Dockerfile:
+The default configuration to run containers creates an image based on the current version of cBioPortal. The branch used to build the image is specified in the Dockerfile.
+
+To use a different branch, you must know the branch and commit name `<branch_name>` `<commit>`you want to use to your image, and specify them when you create image:
+
 ```
-#RUN git fetch https://github.com/thehyve/cbioportal.git my_development_branch \
-#       && git checkout commit_hash_in_branch
+docker build --no-cache -t cbioportal-image  --build-arg BRANCH=<branch_name> COMMIT=<commit> .  
 ```
-and replace it with:
+
+Check result with inspect docker command
+
 ```
-RUN git fetch https://github.com/cbioportal/cbioportal.git rc \
-       && git checkout 6b9356aecdce4068543156e6b1b4509ce89cae66
+docker inspect cbioportal-image | grep "thehyve.cbioportal"
 ```
 
 ## Build the new Docker image
+
 Once you have done your changes, you can build the image by going to your cBioPortal Docker directory and typing:
+
 ```
 docker build -t cbioportal-image .
 ```
 
 You could include a version to the image name by using a `:`. For example:
+
 ```
 docker build -t cbioportal-image:1.11.2 .
 ```

--- a/docs/adjusting_configuration.md
+++ b/docs/adjusting_configuration.md
@@ -14,10 +14,10 @@ diff portal.properties portal.properties.EXAMPLE
 
 The default configuration to run containers creates an image based on the current version of cBioPortal. The branch used to build the image is specified in the Dockerfile.
 
-To use a different branch, you must know the branch and commit name `<branch_name>` `<commit>`you want to use to your image, and specify them when you create image:
+To use a different branch, you must know the branch name and commit sha1 `<branch_name>` `<commit_sha1>` you want to use to your image, and specify them when you create image:
 
 ```
-docker build --no-cache -t cbioportal-image  --build-arg BRANCH=<branch_name> COMMIT=<commit> .  
+docker build --no-cache -t cbioportal-image  --build-arg BRANCH=<branch_name> COMMIT=<commit_sha1> .  
 ```
 
 Check result with inspect docker command


### PR DESCRIPTION

when we fetch a specific branch, we should use a build-arg.

A Dockerfile shouldn't be modify by end-user.