### PR TITLE
Modify properties for more clean version of cBioPortal

### DIFF
--- a/portal.properties
+++ b/portal.properties
@@ -16,7 +16,7 @@ db.version=${db.version}
 
 # web page cosmetics
 skin.title=Local cBioPortal instance
-skin.email_contact=cbioportal at googlegroups dot com
+skin.email_contact=
 skin.authorization_message=Access to this portal is only available to authorized users.
 skin.example_study_queries=tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast
 skin.data_sets_header=The portal currently contains data from the following cancer genomics studies.  The table below lists the number of available samples per data type and tumor.
@@ -36,17 +36,17 @@ skin.right_logo=
 skin.tag_line_image=tag_line.png
 
 # setting controlling which tabs to hide.
-skin.show_news_tab=true
+skin.show_news_tab=false
 skin.show_data_tab=true
-skin.show_web_api_tab=true
-skin.show_r_matlab_tab=true
-skin.show_tutorials_tab=true
-skin.show_faqs_tab=true
-skin.show_tools_tab=true
-skin.show_about_tab=true
+skin.show_web_api_tab=false
+skin.show_r_matlab_tab=false
+skin.show_tutorials_tab=false
+skin.show_faqs_tab=false
+skin.show_tools_tab=false
+skin.show_about_tab=false
 
 # settings controlling the whats new blurb
-skin.right_nav.whats_new_blurb=<p> &bull;<a href="news.jsp"> <b>New data and features released</b></a><br/> &bull;<a href="tools.jsp"> <b>New tools released</b></a>
+skin.right_nav.whats_new_blurb=
 
 # setting controlling the blurb
 skin.blurb=The cBioPortal for Cancer Genomics provides <b>visualization</b>, <b>analysis</b> and <b>download</b> of large-scale cancer genomics data sets.  <p>Please adhere to <u><a href="http://cancergenome.nih.gov/abouttcga/policies/publicationguidelines"> the TCGA publication guidelines</a></u> when using TCGA data in your publications.</p> <p><b>Please cite</b> <a href="http://www.ncbi.nlm.nih.gov/pubmed/23550210">Gao et al. <i>Sci. Signal.</i> 2013</a> &amp;  <a href="http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract">Cerami et al. <i>Cancer Discov.</i> 2012</a> when publishing results based on cBioPortal.</p>
@@ -62,8 +62,8 @@ skin.login.saml.registration_html=Sign in
 
 # settings controlling what to show in the right navigation bar
 skin.right_nav.show_data_sets=true
-skin.right_nav.show_examples=true
-skin.right_nav.show_testimonials=true
+skin.right_nav.show_examples=false
+skin.right_nav.show_testimonials=false
 
 # settings controlling what to show in the right navigation bar
 skin.study_view.link_text=To build your own case set, try out our enhanced Study View.

--- a/portal.properties
+++ b/portal.properties
@@ -121,20 +121,20 @@ ldap.attributes.email=mail
 # study view settings
 # always show studies with this group
 always_show_study_group=
-mdacc.heatmap.study.meta.url=//bioinformatics.mdanderson.org/study2url?studyid=
-mdacc.heatmap.study.url=//bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?
+mdacc.heatmap.study.meta.url=
+mdacc.heatmap.study.url=
 
 # patient view settings
 patient_view_placeholder=false
-digitalslidearchive.iframe.url=http://cancer.digitalslidearchive.net/index_mskcc.php?slide_name=
-digitalslidearchive.meta.url=http://cancer.digitalslidearchive.net/local_php/get_slide_list_from_db_groupid_not_needed.php?slide_name_filter=
-tumor_image.url=http://cbio.mskcc.org/cancergenomics/tcga-tumor-images/
-tcga_path_report.url=https://github.com/cbioportal/datahub/raw/master/tcga/pathology_reports/pathology_reports.txt
-mdacc.heatmap.patient.url=//bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?participant=
-mdacc.heatmap.meta.url=//bioinformatics.mdanderson.org/participant2maps?participant=
+digitalslidearchive.iframe.url=
+digitalslidearchive.meta.url=
+tumor_image.url=
+tcga_path_report.url=
+mdacc.heatmap.patient.url=
+mdacc.heatmap.meta.url=
 
 # various url's
-segfile.url=http://cbio.mskcc.org/cancergenomics/gdac-portal/seg/
+segfile.url=
 
 # Enable OncoKB annotation (true, false)
 show.oncokb=true


### PR DESCRIPTION
- Remove most tabs, because most of them are specific to the public portal (such as News, which contains news on public loaded studies)
- Remove example queries on the right (specific to public portal)
- Remove URLs that are specific to the public portal.
- Remove some other stuff to make this a more 'clean' version of cBioPortal, which is more appropriate for custom instances.
