### PR TITLE
Remove warning not to use an existing db

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ docker network create cbio-net
 
 ### Step 2 - Run mysql with seed database ###
 Start a MySQL server. The command below stores the database in a folder named
-`/<path_to_save_mysql_db>/db_files/`. This should be an absolute path, that
-does *not* point to a directory already containing database files.
+`/<path_to_save_mysql_db>/db_files/`. This should be an absolute path.
 
 ```
 docker run -d --restart=always \


### PR DESCRIPTION
This was vital and led to confusion when we documented using the
MySQL entrypoint scripts to first load the seed database. Now that
we made that an explicit separate step, I don't think this warning
serves a purpose other than to confuse people who have previously
created a database folder and want to connect a fresh containerised
MySQL server to it.