### PR TITLE
Update upstream doc links to Gitbook hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # cbioportal-docker @ The Hyve #
 
-The [cBioPortal](https://github.com/cBioPortal/cbioportal) project documents a setup to deploy a cBioPortal server using Docker, in [this section of the documentation](https://cbioportal.readthedocs.io/en/latest/#docker).
+The [cBioPortal](https://github.com/cBioPortal/cbioportal) project
+documents a setup to deploy a cBioPortal server using Docker,
+in [this section of the documentation](https://docs.cbioportal.org/#2-4-docker).
 As cBioPortal traditionally did not distinguish between build-time and deploy-time configuration,
 the setup documented there builds the application at runtime,
 and suggests running auxiliary commands in the same container as the webserver.

--- a/docs/using-keycloak.md
+++ b/docs/using-keycloak.md
@@ -3,7 +3,7 @@
 This guide describes a way to Dockerise Keycloak along with
 cBioPortal, for authentication as described in
 the
-[cBioPortal documentation](https://cbioportal.readthedocs.io/en/latest/Authenticating-and-Authorizing-Users-via-keycloak.html#introduction).
+[cBioPortal documentation](https://docs.cbioportal.org/2.2-authorization-and-authentication/authenticating-and-authorizing-users-via-keycloak#introduction).
 
 First, create an isolated network in which the Keycloak and MySQL
 servers can talk to one another.
@@ -52,7 +52,7 @@ docker run -d --restart=always \
 ```
 
 Finally, configure Keycloak and cBioPortal as explained in the
-[cBioPortal documentation](https://cbioportal.readthedocs.io/en/latest/Authenticating-and-Authorizing-Users-via-keycloak.html#configure-keycloak-to-authenticate-your-cbioportal-instance).
+[cBioPortal documentation](https://docs.cbioportal.org/2.2-authorization-and-authentication/authenticating-and-authorizing-users-via-keycloak#configure-keycloak-to-authenticate-your-cbioportal-instance).
 Click [here](adjusting_configuration.md) for a general
 explanation on how to adjust portal properties used when building a
 Docker image for cBioPortal, and remember to specify port 8180 for the


### PR DESCRIPTION
The current documentation has been hosted there since cBioPortal
v2.0.0, but the links from this Docker setup to the main manual
still pointed to the cBioportal v1.x.x documentation on Readthedocs.